### PR TITLE
Addresses warning in console, "Security Warning – String like operator with ARN condition keys"

### DIFF
--- a/Privileged-access-controls/Prevent-root-credentials-management-in-member-accounts-in-AWS-Organizations.json
+++ b/Privileged-access-controls/Prevent-root-credentials-management-in-member-accounts-in-AWS-Organizations.json
@@ -6,7 +6,7 @@
           "Action":"*",
           "Resource": "*",
           "Condition":{
-             "StringLike":{
+             "ArnLike":{
                 "aws:PrincipalArn":[
                    "arn:aws:iam::*:root"
                 ]


### PR DESCRIPTION
Using StringLike with ARN condition keys is not recommended, and results in a warning in the policy editor. See also:

* https://docs.aws.amazon.com/IAM/latest/UserGuide/access-analyzer-reference-policy-checks.html#access-analyzer-reference-policy-checks-security-warning-string-like-operator-with-arn-condition-keys

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
