### PR TITLE
Proposing additional AWS Config actions to the SCP

### DIFF
--- a/Deny-changes-to-security-services/Deny-enabling-and-disabling-AWS-Config.json
+++ b/Deny-changes-to-security-services/Deny-enabling-and-disabling-AWS-Config.json
@@ -18,7 +18,13 @@
              "config:StopConfigurationRecorder",
              "config:DeliverConfigSnapshot",
              "config:DeleteAggregationAuthorization",
-             "config:DeleteEvaluationResults"
+             "config:DeleteEvaluationResults",
+             "config:PutOrganizationConfigRule",
+             "config:PutRemediationConfigurations",
+             "config:DeleteRemediationConfiguration",
+             "config:DeleteServiceLinkedConfigurationRecorder",
+             "config:DeleteRemediationExceptions",
+             "config:DeletePendingAggregationRequest" 
           ],
           "Resource":"*",
           "Condition":{


### PR DESCRIPTION
**Description of changes:**

All of the IAM actions below can be run from the delegated admin account and are therefore within the scope of the SCP:

`"config:PutOrganizationConfigRule"` --> defines a rule applicable to all accounts

`"config:PutRemediationConfigurations"` --> can run automated actions with malicious intent, bypass measures, etc.

`"config:DeleteRemediationConfiguration"` --> can disable automated remediations

`"config:DeleteServiceLinkedConfigurationRecorder"` -->causes reduced visibility into AWS services and overall environment

`"config:DeleteRemediationExceptions"` --> Deleting remediation exceptions would block auto-remediation until the exception is cleared

`"config:DeletePendingAggregationRequest"` --> can disrupt the config of centralized compliance monitoring