### PR TITLE
DenyGrantOnAWSManagedEKSKey example

### DIFF
--- a/Service-specific-controls/Amazon-EKS/DenyGrantOnAWSManagedEKSKey.json
+++ b/Service-specific-controls/Amazon-EKS/DenyGrantOnAWSManagedEKSKey.json
@@ -1,0 +1,14 @@
+{
+  "Sid": "DenyGrantOnAWSManagedEKSKey",
+  "Effect": "Deny",
+  "Action": "kms:CreateGrant",
+  "Resource": "*",
+  "Condition": {
+    "StringEquals": {
+      "kms:ViaService": "eks.REGION.amazonaws.com"
+    },
+    "ForAnyValue:StringLike": {
+      "kms:ResourceAliases": "alias/aws/eks"
+    }
+  }
+}

--- a/Service-specific-controls/README.md
+++ b/Service-specific-controls/README.md
@@ -40,6 +40,7 @@ These policies provide guidance on how to accomplish security objectives for spe
 | Included policy | Rationale | 
 |------|-------------|
 |[Deny Tagging Roles and users with EKS Pod Identities Tags](Amazon-EKS/ProtectPodIdentitiesTagsOnRolesAndUsers.json)| Help ensure that no one can tag IAM users and roles with the tags specific to EKS Pod Identities. This is useful in partnership with an RCP to help ensure that only AWS service principals can set these as session tags, and there is an example of this on our [Resource Control Policy example repo](https://github.com/aws-samples/resource-control-policy-examples/tree/main/Service-specific-controls) |
+|[Deny Grant on AWS managed EKS key](Amazon-EKS/DenyGrantOnAWSManagedEKSKey.json)| Help ensure that no one can create an EKS cluster with non Customer Managed Keys [non KMS CMKs]. As you can only scope CMK per ARN and not metadata, you need to pivot to block creating grant on AWS managed keys and there is an example of this on our [Resource Control Policy example repo](https://github.com/aws-samples/resource-control-policy-examples/tree/main/Service-specific-controls) |
 
 **AWS IAM Roles Anywhere**
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adding a SCP for deny EKS Cluster creation with non Customer managed keys as discussed in https://cloudsecurityforum.slack.com/archives/C6DN616HG/p1781811554192559?thread_ts=1781781350.038849&cid=C6DN616HG


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
