### PR TITLE
Fix EKS pod identity tag deny being case-sensitive

### DIFF
--- a/Service-specific-controls/Amazon-EKS/ProtectPodIdentitiesTagsOnRolesAndUsers.json
+++ b/Service-specific-controls/Amazon-EKS/ProtectPodIdentitiesTagsOnRolesAndUsers.json
@@ -10,15 +10,78 @@
       ],
       "Resource": "*",
       "Condition": {
-        "ForAnyValue:StringEquals": {
-          "aws:TagKeys": [
-            "eks-cluster-arn",
-            "eks-cluster-name",
-            "kubernetes-namespace",
-            "kubernetes-service-account",
-            "kubernetes-pod-name",
-            "kubernetes-pod-uid"
-          ]
+        "Null": {
+          "aws:RequestTag/eks-cluster-arn": "false"
+        }
+      }
+    },
+    {
+      "Sid": "PreventTaggingOfUsersAndRolesWithEKSSpecificTags2",
+      "Effect": "Deny",
+      "Action": [
+        "iam:TagRole",
+        "iam:TagUser"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "Null": {
+          "aws:RequestTag/eks-cluster-name": "false"
+        }
+      }
+    },
+    {
+      "Sid": "PreventTaggingOfUsersAndRolesWithEKSSpecificTags3",
+      "Effect": "Deny",
+      "Action": [
+        "iam:TagRole",
+        "iam:TagUser"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "Null": {
+          "aws:RequestTag/kubernetes-namespace": "false"
+        }
+      }
+    },
+    {
+      "Sid": "PreventTaggingOfUsersAndRolesWithEKSSpecificTags4",
+      "Effect": "Deny",
+      "Action": [
+        "iam:TagRole",
+        "iam:TagUser"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "Null": {
+          "aws:RequestTag/kubernetes-service-account": "false"
+        }
+      }
+    },
+    {
+      "Sid": "PreventTaggingOfUsersAndRolesWithEKSSpecificTags5",
+      "Effect": "Deny",
+      "Action": [
+        "iam:TagRole",
+        "iam:TagUser"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "Null": {
+          "aws:RequestTag/kubernetes-pod-name": "false"
+        }
+      }
+    },
+    {
+      "Sid": "PreventTaggingOfUsersAndRolesWithEKSSpecificTags6",
+      "Effect": "Deny",
+      "Action": [
+        "iam:TagRole",
+        "iam:TagUser"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "Null": {
+          "aws:RequestTag/kubernetes-pod-uid": "false"
         }
       }
     }


### PR DESCRIPTION
The Deny matches the six tag keys through aws:TagKeys, which compares the key case-sensitively. Policies read the same tags back through aws:PrincipalTag/<key>, which folds case. So a request that sets KUBERNETES-NAMESPACE is not denied, and the tag it leaves behind still answers the aws:PrincipalTag/kubernetes-namespace read.

To fix each key moves to its own statement with a Null aws:RequestTag/<key> test. That means "this key is present in the request", and it folds case the same way the read does, so the two sides cannot drift apart. One statement per key, because two keys in one condition block are ANDed and would only fire when a request carried both at once.
